### PR TITLE
solve the fgets problem

### DIFF
--- a/examples/app-template.c
+++ b/examples/app-template.c
@@ -25,9 +25,6 @@
 #include "ndn-lite/encode/key-storage.h"
 #include "ndn-lite/encode/ndn-rule-storage.h"
 
-//To solve the fgets problem
-char* temp_p;
-
 // DEVICE manufacture-created private key
 uint8_t secp256r1_prv_key_bytes[32] = {0};
 
@@ -55,6 +52,7 @@ int
 load_bootstrapping_info()
 {
   FILE * fp;
+  char* temp_p;     //To receive the return value of fgets
   char buf[255];
   char* buf_ptr;
   fp = fopen("../devices/tutorial_shared_info-63884.txt", "r");
@@ -63,7 +61,8 @@ load_bootstrapping_info()
   for (size_t lineindex = 0; lineindex < 4; lineindex++) {
     memset(buf, 0, sizeof(buf));
     buf_ptr = buf;
-    temp_p = fgets(buf, sizeof(buf), fp);       //temp_p is used to solve the fgets problem while doing make
+    temp_p = fgets(buf, sizeof(buf), fp);
+    if(temp_p == NULL) exit(1);     //Exit if fgets failed
     if (lineindex == 0) {
       for (i = 0; i < 32; i++) {
         sscanf(buf_ptr, "%2hhx", &secp256r1_prv_key_bytes[i]);

--- a/examples/app-template.c
+++ b/examples/app-template.c
@@ -25,6 +25,9 @@
 #include "ndn-lite/encode/key-storage.h"
 #include "ndn-lite/encode/ndn-rule-storage.h"
 
+//To solve the fgets problem
+char* temp_p;
+
 // DEVICE manufacture-created private key
 uint8_t secp256r1_prv_key_bytes[32] = {0};
 
@@ -60,7 +63,7 @@ load_bootstrapping_info()
   for (size_t lineindex = 0; lineindex < 4; lineindex++) {
     memset(buf, 0, sizeof(buf));
     buf_ptr = buf;
-    fgets(buf, sizeof(buf), fp);
+    temp_p = fgets(buf, sizeof(buf), fp);       //temp_p is used to solve the fgets problem while doing make
     if (lineindex == 0) {
       for (i = 0; i < 32; i++) {
         sscanf(buf_ptr, "%2hhx", &secp256r1_prv_key_bytes[i]);

--- a/examples/test-repo.c
+++ b/examples/test-repo.c
@@ -27,9 +27,6 @@
 
 #include "ndn-lite/app-support/repo.h"
 
-//To solve the fgets problem
-char* temp_p;
-
 // DEVICE manufacture-created private key
 uint8_t secp256r1_prv_key_bytes[32] = {0};
 
@@ -55,6 +52,7 @@ int
 load_bootstrapping_info()
 {
   FILE * fp;
+  char* temp_p;     //To receive the return value of fgets
   char buf[255];
   char* buf_ptr;
   fp = fopen("../devices/tutorial_shared_info-398.txt", "r");
@@ -63,7 +61,8 @@ load_bootstrapping_info()
   for (size_t lineindex = 0; lineindex < 4; lineindex++) {
     memset(buf, 0, sizeof(buf));
     buf_ptr = buf;
-    temp_p = fgets(buf, sizeof(buf), fp);       //temp_p is used to solve the fgets problem
+    temp_p = fgets(buf, sizeof(buf), fp);
+    if(temp_p == NULL)  exit(1);      //Exit if fgets failed
     if (lineindex == 0) {
       for (i = 0; i < 32; i++) {
         sscanf(buf_ptr, "%2hhx", &secp256r1_prv_key_bytes[i]);

--- a/examples/test-repo.c
+++ b/examples/test-repo.c
@@ -27,6 +27,9 @@
 
 #include "ndn-lite/app-support/repo.h"
 
+//To solve the fgets problem
+char* temp_p;
+
 // DEVICE manufacture-created private key
 uint8_t secp256r1_prv_key_bytes[32] = {0};
 
@@ -60,7 +63,7 @@ load_bootstrapping_info()
   for (size_t lineindex = 0; lineindex < 4; lineindex++) {
     memset(buf, 0, sizeof(buf));
     buf_ptr = buf;
-    fgets(buf, sizeof(buf), fp);
+    temp_p = fgets(buf, sizeof(buf), fp);       //temp_p is used to solve the fgets problem
     if (lineindex == 0) {
       for (i = 0; i < 32; i++) {
         sscanf(buf_ptr, "%2hhx", &secp256r1_prv_key_bytes[i]);

--- a/examples/tutorial-app-sub.c
+++ b/examples/tutorial-app-sub.c
@@ -32,6 +32,9 @@
 #include "ndn-lite/encode/key-storage.h"
 #include "ndn-lite/encode/ndn-rule-storage.h"
 
+//To solve the fgets problem while doing make
+char* temp_p;
+
 // DEVICE manufacture-created private key
 uint8_t secp256r1_prv_key_bytes[32] = {0};
 
@@ -70,7 +73,7 @@ load_bootstrapping_info()
   for (size_t lineindex = 0; lineindex < 4; lineindex++) {
     memset(buf, 0, sizeof(buf));
     buf_ptr = buf;
-    fgets(buf, sizeof(buf), fp);
+    temp_p = fgets(buf, sizeof(buf), fp);       //temp_p is used to solve the fgets problem while doing make
     if (lineindex == 0) {
       for (i = 0; i < 32; i++) {
         sscanf(buf_ptr, "%2hhx", &secp256r1_prv_key_bytes[i]);

--- a/examples/tutorial-app-sub.c
+++ b/examples/tutorial-app-sub.c
@@ -32,9 +32,6 @@
 #include "ndn-lite/encode/key-storage.h"
 #include "ndn-lite/encode/ndn-rule-storage.h"
 
-//To solve the fgets problem while doing make
-char* temp_p;
-
 // DEVICE manufacture-created private key
 uint8_t secp256r1_prv_key_bytes[32] = {0};
 
@@ -65,6 +62,7 @@ int
 load_bootstrapping_info()
 {
   FILE * fp;
+  char* temp_p;     //To receive the return value of fgets
   char buf[255];
   char* buf_ptr;
   fp = fopen("../devices/tutorial_shared_info-24777.txt", "r");
@@ -73,7 +71,8 @@ load_bootstrapping_info()
   for (size_t lineindex = 0; lineindex < 4; lineindex++) {
     memset(buf, 0, sizeof(buf));
     buf_ptr = buf;
-    temp_p = fgets(buf, sizeof(buf), fp);       //temp_p is used to solve the fgets problem while doing make
+    temp_p = fgets(buf, sizeof(buf), fp);
+    if(temp_p == NULL) exit(1);     //Exit if fgets failed
     if (lineindex == 0) {
       for (i = 0; i < 32; i++) {
         sscanf(buf_ptr, "%2hhx", &secp256r1_prv_key_bytes[i]);

--- a/examples/tutorial-app.c
+++ b/examples/tutorial-app.c
@@ -25,6 +25,9 @@
 #include "ndn-lite/encode/key-storage.h"
 #include "ndn-lite/encode/ndn-rule-storage.h"
 
+//To solve the fgets problem while doing make
+char* temp_p;
+
 // DEVICE manufacture-created private key
 uint8_t secp256r1_prv_key_bytes[32] = {0};
 
@@ -63,7 +66,7 @@ load_bootstrapping_info()
   for (size_t lineindex = 0; lineindex < 4; lineindex++) {
     memset(buf, 0, sizeof(buf));
     buf_ptr = buf;
-    fgets(buf, sizeof(buf), fp);
+    temp_p = fgets(buf, sizeof(buf), fp);       //to solve the fgets problem while doing make
     if (lineindex == 0) {
       for (i = 0; i < 32; i++) {
         sscanf(buf_ptr, "%2hhx", &secp256r1_prv_key_bytes[i]);

--- a/examples/tutorial-app.c
+++ b/examples/tutorial-app.c
@@ -25,9 +25,6 @@
 #include "ndn-lite/encode/key-storage.h"
 #include "ndn-lite/encode/ndn-rule-storage.h"
 
-//To solve the fgets problem while doing make
-char* temp_p;
-
 // DEVICE manufacture-created private key
 uint8_t secp256r1_prv_key_bytes[32] = {0};
 
@@ -58,6 +55,7 @@ int
 load_bootstrapping_info()
 {
   FILE * fp;
+  char* temp_p;     //To receive the return value of fgets
   char buf[255];
   char* buf_ptr;
   fp = fopen("../devices/tutorial_shared_info-398.txt", "r");
@@ -66,7 +64,8 @@ load_bootstrapping_info()
   for (size_t lineindex = 0; lineindex < 4; lineindex++) {
     memset(buf, 0, sizeof(buf));
     buf_ptr = buf;
-    temp_p = fgets(buf, sizeof(buf), fp);       //to solve the fgets problem while doing make
+    temp_p = fgets(buf, sizeof(buf), fp);
+    if(temp_p == NULL)  exit(1);      //Exit if fgets failed
     if (lineindex == 0) {
       for (i = 0; i < 32; i++) {
         sscanf(buf_ptr, "%2hhx", &secp256r1_prv_key_bytes[i]);


### PR DESCRIPTION
This is to solve the error that occurs in the make process for quick-start apps, which is "ignoring return value of 'fgets'". The adjustment is to create a variable to receive the return value of fgets. Adjustments happen in 4 files under directory "examples", which are "app-template.c", "test-repo.c", "tutorial-app.c" and "turorial-app-sub.c".